### PR TITLE
Add PKGBUILD.prepend to interfere notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@
 - Used to fix up AUR packages or PKGBUILDs which we don't control ourselves.
 - Every folder represents a package. To fix a package with `pkgname=somepackage` the folder would be `somepackage`. Likewise, several conditions can trigger actions.
 - Several possibilities to proceed to exist:
-  - `PKGBUILD.append`: everything in there is going to be the updated content of the original PKGBUILD. Fixing `build()` as is easy as adding the fixed `build()` into this file. This can be used for all kinds of fixes. If something needs to be added to an array, this is as easy as `makedepend+=(somepackage)`.
-  - `interfere.patch`: a patch file that can be used to fix either multiple files or PKGBUILD if a lot of changes are required. All changes need to be added to this file.
   - `prepare`: A script which is being executed after the building chroot has been set up. It can be used to source environment variables or modify other things before compilation starts.
     - If somethign needs to be set up before the actual compilation process, commands can be pushed by inserting eg. `$CAUR_PUSH 'source /etc/profile'`. Likewise, package conflicts can be solved, eg. as follows: `$CAUR_PUSH 'yes | pacman -S nftables'` (single quotes are important because we want the variables/pipes to evaluate in the guest's runtime and not while interfering)
+  - `interfere.patch`: a patch file that can be used to fix either multiple files or PKGBUILD if a lot of changes are required. All changes need to be added to this file.
+  - `PKGBUILD.prepend`: contents of this file are added to the beginning of PKGBUILD.
+  - `PKGBUILD.append`: contents of this file are added to the end of PKGBUILD. Fixing `build()` as is easy as adding the fixed `build()` into this file. This can be used for all kinds of fixes. If something needs to be added to an array, this is as easy as `makedepend+=(somepackage)`.
   - `on-failure.sh`: A script that is being executed if the build fails.
   - `on-success.sh`: A script that is being executed if the build succeeds.
 - Incrementing `pkgrel` can be done by downloading the PKGBUILD (`chaotic get somepackage`), increasing its pkgrel temporarily (`chaotic bump somepackage`) and building it afterward (`chaotic mkd somepackage`).


### PR DESCRIPTION
This adds a description of `PKGBUILD.prepend` to the interfere section.  Also reorders bullets to the order in which they're applied during interfere.